### PR TITLE
Fixing the restart command

### DIFF
--- a/.ebextensions/03run.config
+++ b/.ebextensions/03run.config
@@ -1,4 +1,4 @@
-commands:
+container_commands:
   01-restart-le:
     command: service logentries restart
 services:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Two environment variables are required:
 
 ## Enhancements and Known Issues
 
-* How to better force / handle restart? I've noticed that logs may not begin forwarding until a second deploy or restart after the initial run on new EB environment.
 * The agent doesn't forward CPU stats.  This could be a limit of the le agent on AWS EB AMI. I haven't researched further.
 
 ## Resources


### PR DESCRIPTION
By using container_commands, the restart will run after it register the log files, so that will fix the issue of it only being activated after a second deploy.
